### PR TITLE
Add support/testing for keyboardActivated and others to {{keyboard-shortcut}}

### DIFF
--- a/addon/modifiers/keyboard-shortcut.js
+++ b/addon/modifiers/keyboard-shortcut.js
@@ -20,14 +20,24 @@ if (gte('3.12.0')) {
     keyboardFirstResponder = false;
     keyboardEventType = 'keypress';
 
-
     didReceiveArguments() {
       this.key = this.args.positional[0];
 
-      // Future TODO: support specifying keyboardEventType, keyboardActivated,
-      // keyboardPriority, and keyboardFirstResponder via named arguments.
-      // This should be straightforward, just needs test coverage.
+      if ('keyboardActivated' in this.args.named) {
+        this.keyboardActivated = this.args.named.keyboardActivated
+      }
 
+      if ('keyboardPriority' in this.args.named) {
+        this.keyboardPriority = this.args.named.keyboardPriority
+      }
+
+      if ('keyboardFirstResponder' in this.args.named) {
+        this.keyboardFirstResponder = this.args.named.keyboardFirstResponder
+      }
+
+      if ('keyboardEventType' in this.args.named) {
+        this.keyboardEventType = this.args.named.keyboardEventType
+      }
     }
 
     didInstall() {
@@ -46,11 +56,11 @@ if (gte('3.12.0')) {
     }
 
     has(triggerName) {
-      return triggerName === this.keyboardEventName;
+      return triggerName === this.keyboardEventName && this.keyboardActivated
     }
 
     trigger(listenerName) {
-      if (listenerName === this.keyboardEventName) {
+      if (this.keyboardActivated && listenerName === this.keyboardEventName) {
         this.element.click();
       }
     }

--- a/addon/modifiers/on-keyboard.js
+++ b/addon/modifiers/on-keyboard.js
@@ -37,7 +37,6 @@ if (gte('3.12.0')) {
       // keyboardPriority, and keyboardFirstResponder via named arguments.
       // This should be straightforward, just needs test coverage and some API
       // decisions.
-
     }
 
     didInstall() {

--- a/tests/acceptance/element-modifiers-test.js
+++ b/tests/acceptance/element-modifiers-test.js
@@ -1,4 +1,4 @@
-import { focus, visit, currentURL } from '@ember/test-helpers';
+import { focus, visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { gte } from 'ember-compatibility-helpers';
@@ -23,11 +23,76 @@ if (gte('3.12.0')) {
       await textChanged(
         assert,
         () => keyPress('KeyB'), {
-          selectorName: 'button',
+          selectorName: 'b-button',
           beforeValue: 'button press not triggered',
           afterValue: 'button press triggered'
         });
     });
+
+    test('KeyC button shortcut should only fire when keyboard is activated', async function(assert) {
+      assert.expect(5);
+
+      await textChanged(
+        assert,
+        () => keyPress('KeyC'), {
+          selectorName: 'c-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press not triggered'
+        });
+
+      await click('[data-test-checkbox]')
+      await textChanged(
+        assert,
+        () => keyPress('KeyC'), {
+          selectorName: 'c-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press triggered'
+        });
+    });
+
+    test('KeyD button shortcut for keydown should fire', async function(assert) {
+      assert.expect(5);
+
+      await textChanged(
+        assert,
+        () => keyPress('KeyD'), {
+          selectorName: 'd-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press not triggered'
+        });
+
+      await textChanged(
+        assert,
+        () => keyDown('KeyD'), {
+          selectorName: 'd-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press triggered'
+        });
+    });
+
+    test('KeyP button shortcut should only fire highest priority', async function(assert) {
+      assert.expect(5);
+
+      await fillIn('[data-test-priority]', 1);
+
+      await textChanged(
+        assert,
+        () => keyDown('KeyD'), {
+          selectorName: 'd-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press not triggered'
+        });
+
+      await textChanged(
+        assert,
+        () => keyPress('KeyP'), {
+          selectorName: 'p-button',
+          beforeValue: 'button press not triggered',
+          afterValue: 'button press triggered'
+        });
+
+    });
+
 
     test('Enter text input shortcut', async function(assert) {
       assert.expect(5);

--- a/tests/dummy/app/controllers/test-scenario/element-modifiers.js
+++ b/tests/dummy/app/controllers/test-scenario/element-modifiers.js
@@ -1,19 +1,24 @@
 import Controller from '@ember/controller';
-
+import { action } from '@ember/object';
 export default class extends Controller {
   constructor(...args) {
     super(...args);
 
-    this.wasButtonTriggered = false;
-    this.wasEnterPressedInInput = false;
+    this.priority = 0
+  }
 
-    this.actions = {
-      onTriggerButton() {
-        this.set('wasButtonTriggered', true);
-      },
-      onEnterPressedInInput() {
-        this.set('wasEnterPressedInInput', true);
-      }
-    }
+  @action
+  changeSetting(name, e) {
+    this.set(name, e.target.value)
+  }
+
+  @action
+  changePriority(e) {
+    this.set('priority', e.target.value)
+  }
+
+  @action
+  onEnterPressedInInput() {
+    this.set('wasEnterPressedInInput', true)
   }
 }

--- a/tests/dummy/app/templates/test-scenario/element-modifiers.hbs
+++ b/tests/dummy/app/templates/test-scenario/element-modifiers.hbs
@@ -1,14 +1,70 @@
-<button {{action (action 'onTriggerButton')}} {{keyboard-shortcut 'KeyB'}}>Press me or press "B"</button>
+<div>
+  <button type="button" 
+    {{on "click" (fn (mut this.bButtonTriggered) true)}} 
+    {{keyboard-shortcut 'KeyB'}}>
+    Press me or press "B"
+  </button>
 
-<span data-test-button>
-  {{if wasButtonTriggered 'button press triggered' 'button press not triggered'}}
-</span>
+  <div data-test-b-button>
+    {{if this.bButtonTriggered 'button press triggered' 'button press not triggered'}}
+  </div>
+</div>
 
-<input type="text"
-  oninput={{action (mut this.textFieldValue) value="target.value"}}
-  {{on-keyboard "Enter" (action 'onEnterPressedInInput')}}
+<div>
+  <label>
+    <input data-test-checkbox type="checkbox" value={{this.keyboardActivated}} 
+      {{on 'change' (fn this.changeSetting 'keyboardActivated')}} 
+    />Enable "C" keyboard shortcut
+  </label>
+
+  <button type="button"
+    {{on "click" (fn (mut this.cButtonTriggered) true)}} 
+    {{keyboard-shortcut 'KeyC' keyboardActivated=this.keyboardActivated}}>
+    Press me or press "C" (if the checkbox is checked)
+  </button>
+
+  <div data-test-c-button>
+    {{if this.cButtonTriggered 'button press triggered' 'button press not triggered'}}
+  </div>
+</div>
+
+<div>
+  <button type="button" 
+    {{on "click" (fn (mut this.dButtonTriggered) true)}} 
+    {{keyboard-shortcut 'KeyD' keyboardEventType='keydown'}}>
+    Press me or press "D"
+  </button>
+
+  <div data-test-d-button>
+    {{if this.dButtonTriggered 'button press triggered' 'button press not triggered'}}
+  </div>
+</div>
+
+<input type="text" 
+  {{on "input" (fn this.changeSetting 'textFieldValue')}} 
+  {{on-keyboard "Enter" this.onEnterPressedInInput}}
 >
-
 <span data-test-text-field>
-  {{if wasEnterPressedInInput 'enter pressed while input focused' 'enter not pressed while input focused'}}
+  {{if this.wasEnterPressedInInput 'enter pressed while input focused' 'enter not pressed while input focused'}}
 </span>
+
+<div>
+  Priority:
+    <label for="">
+    <input data-test-priority type="text" value={{this.priority}} 
+      {{on 'input' this.changePriority}} 
+    />
+      Take Priority
+    </label>
+  <div>
+    <button type="button" 
+      {{on "click" (fn (mut this.priorityKeyFired) true)}} 
+      {{keyboard-shortcut 'KeyP' keyboardPriority=this.priority}}>
+      Press me or press "P"
+    </button>
+    <div data-test-p-button>
+      {{if this.priorityKeyFired 'button press triggered' 'button press not triggered'}}
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
Added support and testing for `keyboardActivated`, `keyboardPriority`, `keyboardFirstResponder`, and `keyboardEventType` for the `{{keyboard-shortcut}}` modifier to help out with this [open PR](https://github.com/adopted-ember-addons/ember-keyboard/pull/111) 

Didn't touch the `{{keyboard-on}}` modifier yet. 